### PR TITLE
Misc. fixes and minor features (Lockouts & XY-zero)

### DIFF
--- a/firmware/rpi/app/MemberRecord.py
+++ b/firmware/rpi/app/MemberRecord.py
@@ -41,6 +41,15 @@ from PyQt5.QtCore import QObject, pyqtSlot, pyqtSignal, pyqtProperty
 class MemberRecord(QObject):
     recordChanged = pyqtSignal()
 
+    ACCESS_LEVEL=['User','Trainer','ARM','RM','Admin']
+    LEVEL_USER=0
+    LEVEL_TRAINER=1
+    LEVEL_ARM=2
+    LEVEL_RM=3
+    LEVEL_ADMIN=4
+    LEVEL_HEADRM=4 # Equiv of Admin
+    LEVEL_NOACCESS=-1
+
     def __init__(self, initRecord = []):
         QObject.__init__(self)
         self.clear()

--- a/firmware/rpi/app/README.md
+++ b/firmware/rpi/app/README.md
@@ -20,11 +20,22 @@ Testing on Development Host
 
 `127.0.1.1	ubuntu devel`
 
+## Run MQTT broker (if desired)
+
+`sudo mosquito &`
+
+## Run backend auth database
+
+`cd ~/authserver`
+`python authserver.py`
+# (See README.md in authserver directory for more)
+
 ## Run the app
 
 The `ratt-devhost.ini` config file contains settings to allow the app
 to run on the development host.
 
+`cd ~/ratt/firmware/rpi/app`
 `./main.py --ini ./ratt-devhost.ini`
 
 

--- a/firmware/rpi/app/ViewEnabled.qml
+++ b/firmware/rpi/app/ViewEnabled.qml
@@ -97,7 +97,11 @@ View {
       status.setKeyActives(true, false, false, true);
       enabledSecs = 0;
       activeSecs = 0;
-      idleTimeoutSecs = config.Personality_TimeoutSeconds;
+      if (activeMemberRecord.level > 0) {
+        idleTimeoutSecs = config.Personality_AdminTimeoutSeconds;
+      } else {
+        idleTimeoutSecs = config.Personality_TimeoutSeconds;
+      } 
       idleSecs = idleTimeoutSecs;
       updateTime();
 

--- a/firmware/rpi/app/ViewHoming.qml
+++ b/firmware/rpi/app/ViewHoming.qml
@@ -44,7 +44,7 @@ View {
 
     function _show() {
       status.keyEscActive = true;
-      status.keyReturnActive = config.Personality_HomingManualOverrideEnabled;
+      status.keyReturnActive = ((activeMemberRecord.level > 0) || (config.Personality_HomingManualOverrideEnabled));
       status.keyUpActive = false;
       status.keyDownActive = false;
 
@@ -73,10 +73,11 @@ View {
     }
 
     function keyReturn(pressed) {
-      if (config.Personality_HomingManualOverrideEnabled) {
-        if (pressed)
+      if ((activeMemberRecord.level > 0) || (config.Personality_HomingManualOverrideEnabled)) {
+        if (pressed) {
           overrideTimer.start();
-        else
+          appWindow.uiEvent('HomingOverride');
+        } else
           overrideTimer.stop();
       }
 

--- a/firmware/rpi/app/ViewLockedOutLoaderContent.qml
+++ b/firmware/rpi/app/ViewLockedOutLoaderContent.qml
@@ -27,6 +27,7 @@ ColumnLayout {
         id: reasonText
         width: sv.width
         text: personality.lockReason
+        horizontalAlignment: Text.AlignHCenter
         font.pixelSize: 12
         font.weight: Font.DemiBold
         wrapMode: Text.Wrap

--- a/firmware/rpi/app/personalities/PersonalityBase.py
+++ b/firmware/rpi/app/personalities/PersonalityBase.py
@@ -384,7 +384,10 @@ class PersonalityBase(PersonalityStateMachine):
                 self.cond.wakeAll()
 
                 if len(message):
-                    self._lockReason = message
+                    try:
+                      self._lockReason = json.loads(message)['reason']
+                    except:
+                      self._lockReason = message
                 else:
                     self._lockReason = '(no reason given)'
                 self.lockReasonChanged.emit()

--- a/firmware/rpi/app/personalities/PersonalityLaserCutter.py
+++ b/firmware/rpi/app/personalities/PersonalityLaserCutter.py
@@ -63,6 +63,7 @@ class Personality(PersonalitySimple):
         self.states[self.STATE_HOMING_OVERRIDE] = self.stateHomingOverride
 
         self._needsHoming = True
+        print "BKG NEEDS HOMING"
 
     # returns true if the tool is currently homed (generally connected to the
     # Y limit switch on a laser gantry)
@@ -129,9 +130,10 @@ class Personality(PersonalitySimple):
                     return self.exitAndGoto(self.STATE_HOMING_FAILED)
 
             if self.wakereason == self.REASON_UI:
+                print "BKG {0} {1}".format(self.uievent,self.activeMemberRecord)
                 if self.uievent == 'HomingAborted' or self.uievent == 'HomingTimeout':
                     return self.exitAndGoto(self.STATE_IDLE)
-                elif self.uievent == 'HomingOverride' and self.app.config.value('Personality.HomingManualOverrideEnabled'):
+                elif self.uievent == 'HomingOverride' and ((self.activeMemberRecord.level > 0) or (self.app.config.value('Personality.HomingManualOverrideEnabled'))):
                     return self.exitAndGoto(self.STATE_HOMING_OVERRIDE)
 
             return False

--- a/firmware/rpi/app/personalities/PersonalitySimple.py
+++ b/firmware/rpi/app/personalities/PersonalitySimple.py
@@ -186,6 +186,8 @@ class Personality(PersonalityBase):
             self.wakeOnRFID(True)
             self.pin_led1.set(LOW)
             self.pin_led2.set(LOW)
+            if self.wasLockedOut:
+                return self.exitAndGoto(self.STATE_LOCK_OUT)
             self.wakeOnTimer(enabled=True, interval=500, singleShot=True)
             return self.goActive()
 
@@ -565,6 +567,10 @@ class Personality(PersonalityBase):
             return self.goActive()
 
         elif self.phACTIVE:
+            if self.wakereason == self.REASON_RFID_ALLOWED and self.activeMemberRecord.level > 1:
+                self.wasLockedOut=True
+                return self.exitAndGoto(self.STATE_ACCESS_ALLOWED)
+
             if self.wakereason == self.REASON_TIMER:
                 if self.pin_led1.get() == LOW:
                     self.pin_led1.set(HIGH)

--- a/firmware/rpi/app/personalities/PersonalityStateMachine.py
+++ b/firmware/rpi/app/personalities/PersonalityStateMachine.py
@@ -120,6 +120,7 @@ class PersonalityStateMachine(QThread):
 
         self.timerStart.connect(self.timer.start)
         self.timerStop.connect(self.timer.stop)
+        self.wasLockedOut = False
 
         self.lockoutPending = False
         self.quit = False
@@ -173,6 +174,7 @@ class PersonalityStateMachine(QThread):
                     self.telemetryEvent.emit('personality/lockout', json.dumps({'state': 'unlocked'}))
 
                 self.lockoutPending = False
+                self.wasLockedOut = False
                 if self.state == self.STATE_LOCK_OUT:
                     self.exitAndGoto(self.STATE_INIT)
 


### PR DESCRIPTION
- ARM/ARMs can log-into locked-out resources
- "Lockout" messages displays "message" (not JSON payload)
- Admin timeout value works (used normal timeout before)
- Laser ARMs/RMs can use blue button to override XY zero
- README clarifications
